### PR TITLE
Log a warning if userId and deviceId are null

### DIFF
--- a/Sources/Skylab/SkylabClient.swift
+++ b/Sources/Skylab/SkylabClient.swift
@@ -89,8 +89,9 @@ public class DefaultSkylabClient : SkylabClient {
             let userContext = self.addContext(user:self.user)
             
             let userId = userContext["user_id"]
-            if userId == nil {
-                print("[Skylab] WARN: userId is nil; no variants fetched")
+            let deviceId = userContext["device_id"]
+            if userId == nil && deviceId == nil {
+                print("[Skylab] WARN: user id and device id are nil; no variants fetched")
                 return
             }
             

--- a/Sources/Skylab/SkylabClient.swift
+++ b/Sources/Skylab/SkylabClient.swift
@@ -91,7 +91,7 @@ public class DefaultSkylabClient : SkylabClient {
             let userId = userContext["user_id"]
             let deviceId = userContext["device_id"]
             if userId == nil && deviceId == nil {
-                print("[Skylab] WARN: user id and device id are nil; no variants fetched")
+                print("[Skylab] WARN: user id and device id are null; amplitude will not be able to resolve identity")
             }
             
             do {

--- a/Sources/Skylab/SkylabClient.swift
+++ b/Sources/Skylab/SkylabClient.swift
@@ -92,7 +92,6 @@ public class DefaultSkylabClient : SkylabClient {
             let deviceId = userContext["device_id"]
             if userId == nil && deviceId == nil {
                 print("[Skylab] WARN: user id and device id are nil; no variants fetched")
-                return
             }
             
             do {

--- a/Sources/Skylab/SkylabClient.swift
+++ b/Sources/Skylab/SkylabClient.swift
@@ -86,6 +86,11 @@ public class DefaultSkylabClient : SkylabClient {
         DispatchQueue.global(qos: .background).async {
             let session = URLSession.shared
 
+            if self.user?.userId == nil || self.user?.userId == "" {
+                print("[Skylab] WARN: userId is nil or empty; no varients fetched")
+                return
+            }
+            
             let userContext = self.addContext(user:self.user)
             do {
                 let requestData = try JSONSerialization.data(withJSONObject: userContext, options: [])

--- a/Sources/Skylab/SkylabClient.swift
+++ b/Sources/Skylab/SkylabClient.swift
@@ -86,12 +86,14 @@ public class DefaultSkylabClient : SkylabClient {
         DispatchQueue.global(qos: .background).async {
             let session = URLSession.shared
 
-            if self.user?.userId == nil || self.user?.userId == "" {
-                print("[Skylab] WARN: userId is nil or empty; no varients fetched")
+            let userContext = self.addContext(user:self.user)
+            
+            let userId = userContext["user_id"]
+            if userId == nil {
+                print("[Skylab] WARN: userId is nil; no variants fetched")
                 return
             }
             
-            let userContext = self.addContext(user:self.user)
             do {
                 let requestData = try JSONSerialization.data(withJSONObject: userContext, options: [])
                 let b64encodedUrl = requestData.base64EncodedString().replacingOccurrences(of: "+", with: "-")


### PR DESCRIPTION
I chose to return if the user ID is empty since we know that no flags will be fetched (?). 

Let me know if you would rather perform the call regardless.