### PR TITLE
feat: Clean up enrollment ID; Rename to Assignment

### DIFF
--- a/Sources/Skylab/SkylabClient.swift
+++ b/Sources/Skylab/SkylabClient.swift
@@ -27,8 +27,6 @@ public extension SkylabClient {
     }
 }
 
-let EnrollmentIdKey: String = "com.amplitude.flags.enrollmentId"
-
 public class DefaultSkylabClient : SkylabClient {
 
     internal let apiKey: String
@@ -37,7 +35,6 @@ public class DefaultSkylabClient : SkylabClient {
     internal var userId: String?
     internal var user: SkylabUser?
     internal var contextProvider: ContextProvider?
-    internal var enrollmentId: String?
 
     init(apiKey: String, config: SkylabConfig) {
         self.apiKey = apiKey
@@ -167,22 +164,7 @@ public class DefaultSkylabClient : SkylabClient {
     }
 
     func loadFromStorage() -> Void {
-        self.loadEnrollmentId()
         self.storage.load()
         print("[Skylab] loaded \(self.storage.getAll())")
     }
-
-    func loadEnrollmentId() -> Void {
-        enrollmentId = UserDefaults.standard.string(forKey: EnrollmentIdKey)
-        if (enrollmentId == nil) {
-            enrollmentId = generateEnrollmentId()
-            print("generated \(enrollmentId!)")
-            UserDefaults.standard.set(enrollmentId, forKey: EnrollmentIdKey)
-        }
-    }
-}
-
-func generateEnrollmentId() -> String {
-    let letters = "abcdefghijklmnopqrstuvwxyz0123456789"
-    return String((0..<25).map{ _ in letters.randomElement()! })
 }

--- a/Sources/Skylab/SkylabConfig.swift
+++ b/Sources/Skylab/SkylabConfig.swift
@@ -9,7 +9,7 @@ import Foundation
 
 public struct SkylabConfig {
     public let debug: Bool
-    public let debugEnrollmentRequests: Bool
+    public let debugAssignmentRequests: Bool
     public let fallbackVariant: Variant?
     public let initialFlags: [String: Variant]
     public let instanceName: String
@@ -17,14 +17,14 @@ public struct SkylabConfig {
 
     public init(
         debug: Bool = SkylabConfig.Defaults.Debug,
-        debugEnrollmentRequests: Bool = SkylabConfig.Defaults.DebugEnrollmentRequests,
+        debugAssignmentRequests: Bool = SkylabConfig.Defaults.DebugAssignmentRequests,
         fallbackVariant: Variant? = SkylabConfig.Defaults.FallbackVariant,
         initialFlags: [String: Variant] = SkylabConfig.Defaults.InitialFlags,
         instanceName: String = SkylabConfig.Defaults.InstanceName,
         serverUrl: String = SkylabConfig.Defaults.ServerUrl
     ) {
         self.debug = debug
-        self.debugEnrollmentRequests = debugEnrollmentRequests
+        self.debugAssignmentRequests = debugAssignmentRequests
         self.fallbackVariant = fallbackVariant
         self.initialFlags = initialFlags
         self.instanceName = instanceName
@@ -33,7 +33,7 @@ public struct SkylabConfig {
 
     public struct Defaults {
         public static let Debug: Bool = false
-        public static let DebugEnrollmentRequests: Bool = false
+        public static let DebugAssignmentRequests: Bool = false
         public static let FallbackVariant: Variant? = nil
         public static let InitialFlags: [String: Variant] = [:]
         public static let InstanceName: String = ""


### PR DESCRIPTION
Remove the enrollment ID from the code base since it is no longer being used.

Talked with curtis about "enrollment" and that we would like to call it "assignment" instead.